### PR TITLE
Make responsive estimate section

### DIFF
--- a/layouts/partials/estimate/estimate.html
+++ b/layouts/partials/estimate/estimate.html
@@ -1,6 +1,6 @@
 <div class="w-full flex flex-col justify-center items-center py-4">
     <h2 class="text-4xl font-extralight text-center text-black uppercase tracking-wider mb-8">free estimate how it works</h2>
-    <div class="flex w-full md:w-[70vw] justify-between items-center p-4">
+    <div class="flex w-full md:flex-row flex-col md:w-[70vw] justify-between items-center p-4">
         <div class="flex flex-col justify-center items-center">
             {{ partial "icons/chat.html" . }}
             <p class="uppercase mt-4 tracking-normal text-[#757575] font-bold md:text-xl text-center">contact us</p>


### PR DESCRIPTION
I was working on mobile version of _**Free Estimate**_ section.

![image](https://github.com/user-attachments/assets/4539e352-842c-4b9d-b194-2a1b1e8bb474)
![image](https://github.com/user-attachments/assets/68988620-21b4-4fdb-a785-43627f133ecc)


